### PR TITLE
Fix warning: Creation of dynamic property warnings in PHP 8.x

### DIFF
--- a/class/class.payfirma.php
+++ b/class/class.payfirma.php
@@ -80,6 +80,24 @@ function sanitize($input) {
  */
 class WC_Gateway_Payfirma extends WC_Payment_Gateway
 {
+    public $id;
+    public $has_fields;
+    public $method_title;
+    public $method_description;
+    public $title;
+    public $description;
+    public $client_secret;
+    public $client_id;
+    public $keys_val;
+    public $http_force;
+    public $env_error;
+    public $disablegateway_js;
+    public $sslcheck;
+    public $forcesslchecked;
+    public $api_info_valid;
+    public $currency_valid;
+    public $enabled;
+
     public function __construct()
     {
 


### PR DESCRIPTION
This declares the variables used by the constructor to eliminate deprecation warnings in PHP 8.x: 

`Creation of dynamic property WC_Gateway_Payfirma::$client_secret is deprecated` (etc.)

Note: I declared them as public in case other parts of your code are accessing them directly. They could be tightened up if not. This fixes the warnings (and saves some disk space in system logs.)